### PR TITLE
Adding support to Cassandra database.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dep_current.txt
 .classpath
 .project
 .settings
+.toDelete

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,11 @@
                 <artifactId>commons-codec</artifactId>
                 <version>1.10</version>
             </dependency>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>3.0.0</version>
+            </dependency>
 
             <!-- Provided dependencies -->
             <dependency>
@@ -323,6 +328,12 @@
                 <groupId>org.apache.tomcat</groupId>
                 <artifactId>tomcat-catalina</artifactId>
                 <version>7.0.55</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.cassandraunit</groupId>
+                <artifactId>cassandra-unit</artifactId>
+                <version>3.0.0.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/processors/cassandra/CONFIG.md
+++ b/processors/cassandra/CONFIG.md
@@ -1,0 +1,78 @@
+# Configuration Options
+
+This processors persists an audit event to a Cassandra database connection.
+The event is stored in a database table of the following structure:
+
+```
+CREATE TABLE events (
+  eventId VARCHAR PRIMARY KEY,
+  auditStream VARCHAR,
+  eventJson VARCHAR);
+```
+- The `eventId` field holds an identifier that uniquely identifies
+  audit events. See below for more information on this field, and
+  how to configure the length of the field. Note that the field
+  length in the database must match the length configuration for
+  creation of that id string in this library. The collation of this
+  field is `ASCII` when using the default `eventId` generator that
+  comes with this library, but the correct collation depends on the
+  method of how the event ID is being generated.
+- The `auditStream` field holds the name of the audit stream a
+  specific event occurred in. Note that field length in the database
+  must be greater or equal to the longest possible audit stream name
+  used in this library. The collation of this field is `ASCII` when
+  `ASCII`-only audit stream names are being used, but the correct
+  collation depends on the method of how the audit streams are named
+  in a specific deployment.
+- The `eventJson` holds a JSON representation of the JSON-serialized
+  audit event. A good choice for the type of this field is a large
+  text object field, such as `CLOB`, `LONGTEXT`, or similar. The
+  recommended collation of this field is `UTF-8`.
+
+## Generic Settings for the Cassandra Processors
+
+### audit.processor.cassandra.insertEventSqlStmt
+
+Sets the SQL statement to be used when inserting events in the database
+table storing events (i.e. the `events` table above). The statement must
+be parametrized, and the order of the parameters must be:
+
+1. `eventId`
+2. `auditStream`
+3. `eventJson`
+
+An example statement that meets the requirements is:
+
+`INSERT INTO events (eventId, auditStream, eventJson) VALUES (?, ?, ?)`
+
+The syntax of the statement depends on the underlying RDBMS.
+
+Default: `"TODO - CONFIGURE ME!"`
+
+### audit.processor.cassandra.stringEncoding
+
+The encoding to use when when converting bytes to a String.
+
+Default: `UTF-8`
+
+## Cassandra Connection
+
+To connect with Cassandra, the application that integrates with the audit lib must set an open Session instance to the lib.
+This Session instance must pe set as a `processingObject` as follow:
+
+```
+ProcessingObjects processingObjects = new ProcessingObjects();
+processingObjects.add(MapBasedCassandraPropsBuilder.KEY_CASSANDRA_CONNECTION_SESSION,
+        sessionInstance);
+```
+
+**KEY_CASSANDRA_CONNECTION_SESSION=**`audit.processor.cassandra.session`
+
+To audit an event passing this processingObject:
+
+```
+audit.audit(event, AUDIT_STREAM_NAME, processingObjects);
+```
+
+
+

--- a/processors/cassandra/LICENSE.txt
+++ b/processors/cassandra/LICENSE.txt
@@ -1,0 +1,25 @@
+Copyright (c) 2015 - 2016, Michael Beiter <michael@beiter.org>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the names of the
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/processors/cassandra/pom.xml
+++ b/processors/cassandra/pom.xml
@@ -1,0 +1,92 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.beiter.michael.eaudit4j</groupId>
+        <artifactId>processors</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>org.beiter.michael.eaudit4j.processors</groupId>
+    <artifactId>cassandra</artifactId>
+    <packaging>jar</packaging>
+    <version>1.1-SNAPSHOT</version>
+
+    <name>cassandra</name>
+    <description>
+        This module is part of the eAudit4j audit library, providing a simple and pluggable
+        solution for auditing in Java.
+
+        This particular Maven module provides a set of audit processors that persists audit
+        events using Cassandra. Once persisted, the event is passed on without modification.
+    </description>
+    <url>http://mbeiter.github.io/audit4j/docs/${project.version}/${project.artifactId}/</url>
+
+    <dependencies>
+        <!-- Included dependencies -->
+        <dependency>
+            <groupId>org.beiter.michael.eaudit4j</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+        </dependency>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>net.sourceforge.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <scm>
+        <url>https://github.com/mbeiter/audit4j</url>
+        <connection>scm:git:git://github.com/mbeiter/audit4j.git</connection>
+        <developerConnection>scm:git:git@github.com:mbeiter/audit4j.git</developerConnection>
+    </scm>
+
+    <!--
+      Required for 'mvn site/ to build the links correctly. Requires the URL of this module to be set to:
+      <url>http://mbeiter.github.io/audit4j/docs/${project.version}/${project.artifactId}/</url>
+    -->
+    <distributionManagement>
+        <site>
+            <id>github.gh-pages</id>
+            <url>${project.url}</url>
+        </site>
+    </distributionManagement>
+</project>

--- a/processors/cassandra/src/license/licenseDescription.ftl
+++ b/processors/cassandra/src/license/licenseDescription.ftl
@@ -1,0 +1,3 @@
+This file is part of eAudit4j, a library for creating pluggable
+auditing solutions, providing an audit processor that persists
+audit events to a Cassandra database.

--- a/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraProcessor.java
+++ b/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraProcessor.java
@@ -1,0 +1,165 @@
+/*
+ * #%L
+ * This file is part of eAudit4j, a library for creating pluggable
+ * auditing solutions, providing an audit processor that persists
+ * audit events to a Cassandra database.
+ * %%
+ * Copyright (C) 2015 - 2016 Michael Beiter <michael@beiter.org>
+ * %%
+ * All rights reserved.
+ * .
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of the
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ * .
+ * .
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.InvalidQueryException;
+import org.apache.commons.lang3.Validate;
+import org.beiter.michael.eaudit4j.common.AuditErrorConditions;
+import org.beiter.michael.eaudit4j.common.AuditException;
+import org.beiter.michael.eaudit4j.common.CommonProperties;
+import org.beiter.michael.eaudit4j.common.Event;
+import org.beiter.michael.eaudit4j.common.Field;
+import org.beiter.michael.eaudit4j.common.ProcessingObjects;
+import org.beiter.michael.eaudit4j.common.Processor;
+import org.beiter.michael.eaudit4j.common.Reversible;
+import org.beiter.michael.eaudit4j.processors.cassandra.propsbuilder.MapBasedCassandraPropsBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CassandraProcessor implements Processor, Reversible {
+    /**
+     * The logger object for this class
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraProcessor.class);
+
+    /**
+     * A copy of the common properties
+     */
+    protected CommonProperties commonProperties;
+
+    /**
+     * A copy of the processor specific properties
+     */
+    protected CassandraProperties properties;
+
+    @Override
+    public void init(CommonProperties properties) {
+        Validate.notNull(properties, "The validated object 'properties' is null");
+
+        this.commonProperties = new CommonProperties(properties);
+        this.properties = MapBasedCassandraPropsBuilder.build(properties.getAdditionalProperties());
+    }
+
+    @Override
+    public Event process(Event event) throws AuditException {
+        return process(event, commonProperties.getDefaultAuditStream());
+    }
+
+    @Override
+    public Event process(Event event, String auditStreamName) throws AuditException {
+        return process(event, auditStreamName, new ProcessingObjects());
+    }
+
+    @Override
+    public Event process(Event event, String auditStreamName, ProcessingObjects processingObjects) throws AuditException {
+        if (event == null) {
+            final String error = "The validated object 'event' is null";
+            LOG.warn(error);
+            throw new AuditException(AuditErrorConditions.INVALID_EVENT, error);
+        }
+
+        Validate.notBlank(auditStreamName, "The validated character sequence 'auditStreamName' is null or empty");
+        Validate.notNull(processingObjects, "The validated object 'processingObjects' is null");
+
+        // extract the event ID from the event, and throw an exception if the event ID is not present
+        final String eventId;
+        if (event.containsField(properties.getEventIdFieldName())) {
+            final Field eventIdField = event.getField(properties.getEventIdFieldName()); // compiler will optimize this
+            eventId = String.valueOf(eventIdField.getCharValue(properties.getStringEncoding()));
+        } else {
+            final String error = "The required field `event ID` is not present in the event. Have you configured "
+                    + "(1) a processor that adds (random) event IDs, and "
+                    + "(2) configured that processor to run before this processor in the chain, and "
+                    + "(3) configured this processor to use the correct name for the event ID field?";
+            LOG.warn(error);
+            throw new AuditException(AuditErrorConditions.CONFIGURATION, error);
+        }
+
+        final String eventJson = String.valueOf(event.toJson(properties.getStringEncoding()));
+
+        persistEvent(auditStreamName, eventId, eventJson, processingObjects);
+
+        return event;
+    }
+
+    @Override
+    public void cleanUp() {
+        //do nothing
+    }
+
+    @Override
+    public Event revert(Event event) throws AuditException {
+        Validate.notNull(event, "The validated object 'event' is null");
+        // do nothing
+        return event;
+    }
+
+    private Session getSession(ProcessingObjects processingObjects) throws AuditException {
+        if (processingObjects.contains(MapBasedCassandraPropsBuilder.KEY_CASSANDRA_CONNECTION_SESSION)) {
+            return (Session) processingObjects.get(MapBasedCassandraPropsBuilder.KEY_CASSANDRA_CONNECTION_SESSION);
+        } else {
+            final String error = "Cannot retrieve a connection from Cassandra cluster";
+            LOG.warn(error);
+            throw new AuditException(AuditErrorConditions.PROCESSING, error);
+        }
+    }
+
+    private void persistEvent(final String auditStreamName, final String eventId, final String eventJson,
+                              final ProcessingObjects processingObjects)
+            throws AuditException {
+        try {
+            Session session = getSession(processingObjects);
+
+            Statement query = new SimpleStatement(properties.getInsertEventSqlStmt(),
+                    eventId, auditStreamName, eventJson);
+            ResultSet rsEvent = session.execute(query);
+
+            if (!rsEvent.wasApplied()) {
+                final String error = "Error when persisting the audit event. The operation should have affected '1' "
+                        + "index row per field, but a total of 0 rows was affected";
+                LOG.warn(error);
+                throw new AuditException(AuditErrorConditions.PROCESSING, error);
+            }
+        }catch (InvalidQueryException e) {
+            final String error = "Unrecoverable error when executing the SQL transaction";
+            LOG.warn(error, e);
+            throw new AuditException(AuditErrorConditions.PROCESSING, error, e);
+        }
+    }
+}

--- a/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraProperties.java
+++ b/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraProperties.java
@@ -1,0 +1,210 @@
+/*
+ * #%L
+ * This file is part of eAudit4j, a library for creating pluggable
+ * auditing solutions, providing an audit processor that persists
+ * audit events to a Cassandra database.
+ * %%
+ * Copyright (C) 2015 - 2016 Michael Beiter <michael@beiter.org>
+ * %%
+ * All rights reserved.
+ * .
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of the
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ * .
+ * .
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra;
+
+import org.apache.commons.lang3.Validate;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+
+public class CassandraProperties {
+
+    /**
+     * @see CassandraProperties#setInsertEventSqlStmt(String)
+     */
+    private String insertEventSqlStmt;
+
+    /**
+     * @see CassandraProperties#setStringEncoding(String)
+     */
+    private String stringEncoding;
+
+    /**
+     * @see CassandraProperties#setEventIdFieldName(String)
+     */
+    private String eventIdFieldName;
+
+    /**
+     * @see CassandraProperties#setAdditionalProperties(Map)
+     */
+    private Map<String, String> additionalProperties = new ConcurrentHashMap<>();
+
+    /**
+     * Constructs an empty set of Cassandra properties, with most values being set to <code>null</code>, 0, or empty
+     * (depending on the type of the property). Usually this constructor is used if this configuration POJO is populated
+     * in an automated fashion (e.g. injection). If you need to build them manually (possibly with defaults), use or
+     * create a properties builder.
+     * <p>
+     * You can change the defaults with the setters.
+     *
+     * @see org.beiter.michael.eaudit4j.common.propsbuilder.MapBasedCommonPropsBuilder#buildDefault()
+     * @see org.beiter.michael.eaudit4j.common.propsbuilder.MapBasedCommonPropsBuilder#build(Map)
+     */
+    public CassandraProperties() {
+
+        // no code here, constructor just for java docs
+    }
+
+    /**
+     * Creates a set of Cassandra properties from an existing set of Cassandra properties, making a defensive copy.
+     *
+     * @param properties The set of properties to copy
+     * @throws NullPointerException When {@code properties} is {@code null}
+     * @see CassandraProperties ()
+     */
+
+    public CassandraProperties(final CassandraProperties properties) {
+        this();
+
+        Validate.notNull(properties, "The validated object 'properties' is null");
+
+        setInsertEventSqlStmt(properties.getInsertEventSqlStmt());
+        setStringEncoding(properties.getStringEncoding());
+        setEventIdFieldName(properties.getEventIdFieldName());
+        setAdditionalProperties(properties.getAdditionalProperties());
+    }
+
+    /**
+     * @return The event SQL "INSERT" statement (event table)
+     * @see CassandraProperties#setInsertEventSqlStmt(String)
+     */
+    public final String getInsertEventSqlStmt() {
+        return insertEventSqlStmt;
+    }
+
+    /**
+     * Set the SQL statement to insert event records in the event table.
+     *
+     * @param insertEventSqlStmt The SQL statement used to insert audit events to the database
+     * @throws NullPointerException     When the {@code insertEventSqlStmt} is {@code null}
+     * @throws IllegalArgumentException When the {@code insertEventSqlStmt} is {@code empty}
+     */
+    public final void setInsertEventSqlStmt(final String insertEventSqlStmt) {
+
+        Validate.notBlank(insertEventSqlStmt, "The validated character sequence 'insertEventSqlStmt' is null or empty");
+        this.insertEventSqlStmt = insertEventSqlStmt;
+    }
+
+    /**
+     * @return The String encoding
+     * @see CassandraProperties#setStringEncoding(String)
+     */
+    public final String getStringEncoding() {
+        return stringEncoding;
+    }
+
+    /**
+     * Set the String encoding to use when converting bytes to a String
+     *
+     * @param stringEncoding The String encoding to use
+     * @throws NullPointerException     When the {@code stringEncoding} is {@code null}
+     * @throws IllegalArgumentException When the {@code stringEncoding} is {@code empty}
+     */
+    public final void setStringEncoding(final String stringEncoding) {
+
+        Validate.notBlank(stringEncoding, "The validated character sequence 'stringEncoding' is null or empty");
+        this.stringEncoding = stringEncoding;
+    }
+
+    /**
+     * @return the name of the field holding a unique event ID
+     * @see CassandraProperties#setEventIdFieldName(String)
+     */
+    public final String getEventIdFieldName() {
+        return eventIdFieldName;
+    }
+
+    /**
+     * The name of the field in the event that holds a unique event ID.
+     * <p>
+     * This event ID can be created e.g. with the `org.beiter.michael.eaudit4j.processors.eventid.EventIdProcessor`
+     * processor.
+     * <p>
+     * Note that the field (referenced in the INSERT SQL statements both for the events table and the search table)
+     * that holds this value must be long enough to accept a value of the maximum length possible for the value
+     * configured here.
+     *
+     * @param eventIdFieldName the length of the (random) event ID generated by this processor (must be greater 0)
+     * @throws NullPointerException     When the {@code eventIdFieldName} is {@code null}
+     * @throws IllegalArgumentException When the {@code eventIdFieldName} is {@code empty}
+     */
+    public final void setEventIdFieldName(final String eventIdFieldName) {
+        Validate.notBlank(stringEncoding, "The validated character sequence 'eventIdFieldName' is null or empty");
+        this.eventIdFieldName = eventIdFieldName;
+    }
+
+    /**
+     * @return Any additional properties stored in this object that have not explicitly been parsed
+     * @see CassandraProperties#setAdditionalProperties(Map)
+     */
+    public final Map<String, String> getAdditionalProperties() {
+
+        // create a defensive copy of the map and all its properties
+        if (this.additionalProperties == null) {
+            // this should never happen!
+            return new ConcurrentHashMap<>();
+        } else {
+            final Map<String, String> tempMap = new ConcurrentHashMap<>();
+            tempMap.putAll(additionalProperties);
+
+            return tempMap;
+        }
+    }
+
+    /**
+     * Any additional properties which have not been parsed, and for which no getter/setter exists, but are to be
+     * stored in this object nevertheless.
+     * <p>
+     * This property is commonly used to preserve original properties from upstream components that are to be passed
+     * on to downstream components unchanged. This properties set may or may not include properties that have been
+     * extracted from the map, and been made available through this POJO.
+     * <p>
+     * Note that these additional properties may be <code>null</code> or empty, even in a fully populated POJO where
+     * other properties commonly have values assigned to.
+     *
+     * @param additionalProperties The additional properties to store
+     */
+    public final void setAdditionalProperties(final Map<String, String> additionalProperties) {
+
+        // create a defensive copy of the map and all its properties
+        if (additionalProperties == null) {
+            this.additionalProperties = new ConcurrentHashMap<>();
+        } else {
+            this.additionalProperties = new ConcurrentHashMap<>();
+            this.additionalProperties.putAll(additionalProperties);
+        }
+    }
+}

--- a/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/package-info.java
+++ b/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Provides a processor that writes audit events to a Cassandra
+ * database, with the processor managing the connection pool.
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra;

--- a/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/propsbuilder/MapBasedCassandraPropsBuilder.java
+++ b/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/propsbuilder/MapBasedCassandraPropsBuilder.java
@@ -1,0 +1,231 @@
+/*
+ * #%L
+ * This file is part of eAudit4j, a library for creating pluggable
+ * auditing solutions, providing an audit processor that persists
+ * audit events to a Cassandra database.
+ * %%
+ * Copyright (C) 2015 - 2016 Michael Beiter <michael@beiter.org>
+ * %%
+ * All rights reserved.
+ * .
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of the
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ * .
+ * .
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra.propsbuilder;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
+import org.beiter.michael.eaudit4j.processors.cassandra.CassandraProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This class builds a set of {@link CassandraProperties} using the settings obtained from a Map.
+ * <p>
+ * Use the keys from the various KEY_* fields to properly populate the Map before calling this class' methods.
+ */
+// CHECKSTYLE:OFF
+// this is flagged in checkstyle with a missing whitespace before '}', which is a bug in checkstyle
+// suppress warnings about the long variable names
+@SuppressWarnings({"PMD.LongVariable"})
+// CHECKSTYLE:ON
+public final class MapBasedCassandraPropsBuilder {
+
+    /**
+     * The logger object for this class
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(MapBasedCassandraPropsBuilder.class);
+
+    /**
+     * @see CassandraProperties#setInsertEventSqlStmt(String)
+     */
+    public static final String DEFAULT_INSERT_EVENT_SQL_STMT = "TODO - CONFIGURE ME!";
+
+    /**
+     * @see CassandraProperties#setStringEncoding(String)
+     */
+    public static final String DEFAULT_STRING_ENCODING = "UTF-8";
+
+    /**
+     * @see CassandraProperties#setEventIdFieldName(String)
+     */
+    public static final String DEFAULT_EVENT_ID_FIELD_NAME = "TODO - CONFIGURE ME!";
+
+    /**
+     * @see CassandraProperties#setInsertEventSqlStmt(String)
+     */
+    public static final String KEY_INSERT_EVENT_SQL_STMT = "audit.processor.cassandra.insertEventSqlStmt";
+
+    /**
+     * @see CassandraProperties#setStringEncoding(String)
+     */
+    public static final String KEY_STRING_ENCODING = "audit.processor.cassandra.stringEncoding";
+
+    /**
+     * @see CassandraProperties#setEventIdFieldName(String)
+     */
+    public static final String KEY_EVENT_ID_FIELD_NAME = "audit.processor.cassandra.eventIdFieldName";
+
+    public static final String KEY_CASSANDRA_CONNECTION_SESSION = "audit.processor.cassandra.session";
+
+    /**
+     * A private constructor to prevent instantiation of this class
+     */
+    private MapBasedCassandraPropsBuilder() {
+    }
+
+    /**
+     * Creates a set of Cassandra properties that use the defaults as specified in this class.
+     *
+     * @return A set of Cassandra properties with (reasonable) defaults
+     * @see MapBasedCassandraPropsBuilder
+     */
+    public static CassandraProperties buildDefault() {
+
+        return build(new ConcurrentHashMap<String, String>());
+    }
+
+    /**
+     * Initialize a set of Cassandra properties based on key / values in a <code>HashMap</code>.
+     *
+     * @param properties A <code>HashMap</code> with configuration properties, using the keys as specified in this class
+     * @return A {@link CassandraProperties} object with default values, plus the provided parameters
+     * @throws NullPointerException When {@code properties} is {@code null}
+     */
+    // CHECKSTYLE:OFF
+    // this is flagged in checkstyle with a missing whitespace before '}', which is a bug in checkstyle
+    // suppress warnings about this method being too long (not much point in splitting up this one!)
+    // suppress warnings about this method being too complex (can't extract a generic subroutine to reduce exec paths)
+    @SuppressWarnings({"PMD.ExcessiveMethodLength", "PMD.NPathComplexity", "PMD.CyclomaticComplexity", "PMD.StdCyclomaticComplexity", "PMD.ModifiedCyclomaticComplexity"})
+    // CHECKSTYLE:ON
+    public static CassandraProperties build(final Map<String, String> properties) {
+
+        Validate.notNull(properties, "The validated object 'value' is null");
+
+        final CassandraProperties cassandraProperties = new CassandraProperties();
+        String tmp = properties.get(KEY_INSERT_EVENT_SQL_STMT);
+        if (StringUtils.isNotEmpty(tmp)) {
+            cassandraProperties.setInsertEventSqlStmt(tmp);
+            logValue(KEY_INSERT_EVENT_SQL_STMT, tmp);
+        } else {
+            cassandraProperties.setInsertEventSqlStmt(DEFAULT_INSERT_EVENT_SQL_STMT);
+            logDefault(KEY_INSERT_EVENT_SQL_STMT, DEFAULT_INSERT_EVENT_SQL_STMT);
+        }
+
+        tmp = properties.get(KEY_STRING_ENCODING);
+        if (StringUtils.isNotEmpty(tmp)) {
+            cassandraProperties.setStringEncoding(tmp);
+            logValue(KEY_STRING_ENCODING, tmp);
+        } else {
+            cassandraProperties.setStringEncoding(DEFAULT_STRING_ENCODING);
+            logDefault(KEY_STRING_ENCODING, DEFAULT_STRING_ENCODING);
+        }
+
+        tmp = properties.get(KEY_EVENT_ID_FIELD_NAME);
+        if (StringUtils.isNotEmpty(tmp)) {
+            cassandraProperties.setEventIdFieldName(tmp);
+            logValue(KEY_EVENT_ID_FIELD_NAME, tmp);
+        } else {
+            cassandraProperties.setEventIdFieldName(DEFAULT_EVENT_ID_FIELD_NAME);
+            logDefault(KEY_EVENT_ID_FIELD_NAME, DEFAULT_EVENT_ID_FIELD_NAME);
+        }
+
+        // set the additional properties, preserving the originally provided properties
+        // create a defensive copy of the map and all its properties
+        // the code looks a little complicated that "putAll()", but it catches situations where a Map is provided that
+        // supports null values (e.g. a HashMap) vs Map implementations that do not (e.g. ConcurrentHashMap).
+        final Map<String, String> tempMap = new ConcurrentHashMap<>();
+        for (final Map.Entry<String, String> entry : properties.entrySet()) {
+            final String key = entry.getKey();
+            final String value = entry.getValue();
+
+            if (value != null) {
+                tempMap.put(key, value);
+            }
+        }
+        cassandraProperties.setAdditionalProperties(tempMap);
+
+        return cassandraProperties;
+    }
+
+    /**
+     * Create a log entry when a value has been successfully configured.
+     *
+     * @param key   The configuration key
+     * @param value The value that is being used
+     */
+    private static void logValue(final String key, final String value) {
+
+        // Fortify will report a violation here because of disclosure of potentially confidential information.
+        // However, the configuration keys are not confidential, which makes this a non-issue / false positive.
+        if (LOG.isInfoEnabled()) {
+            final StringBuilder msg = new StringBuilder("Key found in configuration ('")
+                    .append(key)
+                    .append("'), using configured value (not disclosed here for security reasons)");
+            LOG.info(msg.toString());
+        }
+
+        // Fortify will report a violation here because of disclosure of potentially confidential information.
+        // The configuration VALUES are confidential. DO NOT activate DEBUG logging in production.
+        if (LOG.isDebugEnabled()) {
+            final StringBuilder msg = new StringBuilder("Key found in configuration ('")
+                    .append(key)
+                    .append("'), using configured value ('");
+            if (value == null) {
+                msg.append("null')");
+            } else {
+                msg.append(value).append("')");
+            }
+            LOG.debug(msg.toString());
+        }
+    }
+
+    /**
+     * Create a log entry when a default value is being used in case the propsbuilder key has not been provided in the
+     * configuration.
+     *
+     * @param key          The configuration key
+     * @param defaultValue The default value that is being used
+     */
+    private static void logDefault(final String key, final String defaultValue) {
+
+        // Fortify will report a violation here because of disclosure of potentially confidential information.
+        // However, neither the configuration keys nor the default propsbuilder values are confidential, which makes
+        // this a non-issue / false positive.
+        if (LOG.isInfoEnabled()) {
+            final StringBuilder msg = new StringBuilder("Key is not configured ('")
+                    .append(key)
+                    .append("'), using default value ('");
+            if (defaultValue == null) {
+                msg.append("null')");
+            } else {
+                msg.append(defaultValue).append("')");
+            }
+            LOG.info(msg.toString());
+        }
+    }
+}

--- a/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/propsbuilder/package-info.java
+++ b/processors/cassandra/src/main/java/org/beiter/michael/eaudit4j/processors/cassandra/propsbuilder/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Provides classes to build the properties required for the
+ * pooled Cassandra processor module.
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra.propsbuilder;

--- a/processors/cassandra/src/test/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraProcessorTest.java
+++ b/processors/cassandra/src/test/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraProcessorTest.java
@@ -1,0 +1,278 @@
+/*
+ * #%L
+ * This file is part of eAudit4j, a library for creating pluggable
+ * auditing solutions, providing an audit processor that persists
+ * audit events to a Cassandra database.
+ * %%
+ * Copyright (C) 2015 - 2016 Michael Beiter <michael@beiter.org>
+ * %%
+ * All rights reserved.
+ * .
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of the
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ * .
+ * .
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra;
+
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.thrift.transport.TTransportException;
+import org.beiter.michael.eaudit4j.common.Audit;
+import org.beiter.michael.eaudit4j.common.Event;
+import org.beiter.michael.eaudit4j.common.CommonProperties;
+import org.beiter.michael.eaudit4j.common.ProcessingObjects;
+import org.beiter.michael.eaudit4j.common.AuditFactory;
+import org.beiter.michael.eaudit4j.common.AuditException;
+import org.beiter.michael.eaudit4j.common.AuditErrorConditions;
+import org.beiter.michael.eaudit4j.common.FactoryException;
+import org.beiter.michael.eaudit4j.common.Encodings;
+import org.beiter.michael.eaudit4j.common.Field;
+import org.beiter.michael.eaudit4j.common.impl.EventBuilder;
+import org.beiter.michael.eaudit4j.common.impl.EventField;
+import org.beiter.michael.eaudit4j.common.propsbuilder.MapBasedCommonPropsBuilder;
+import org.beiter.michael.eaudit4j.processors.cassandra.propsbuilder.MapBasedCassandraPropsBuilder;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class CassandraProcessorTest {
+    public static final String EVENT_ID_FIELD_NAME = "eventId";
+    public static final String EVENT_ID = "1234567890ABCDEF";
+    public static final String T_AUDIT_STREAM_NAME = "1234567890";
+    public static final String T_SUBJECT = "SubjectId-1234";
+    public static final String T_OBJECT = "ObjectId-3456";
+    public static final String T_ACTOR = "ActorId-5678";
+    public static final String T_RESULT = "Some result";
+    public static final String T_EVENT_JSON = "{\"version\":\"1.0\","
+            + "\"fields\":{\"actor\":\"" + T_ACTOR + "\",\"result\":\"" + T_RESULT + "\",\"" + EVENT_ID_FIELD_NAME
+            + "\":\"" + EVENT_ID + "\",\"subject\":\"" + T_SUBJECT + "\",\"byteField\":\"31323334\",\"object\":\""
+            + T_OBJECT + "\"}}";
+
+    @Test
+    public void shouldInsertAnEvent()
+            throws FactoryException, AuditException, IOException, InterruptedException, TTransportException {
+
+        CassandraServer.startCassandra();
+
+        Map<String, String> propsMap = new HashMap<>();
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_EVENT_ID_FIELD_NAME, EVENT_ID_FIELD_NAME);
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_INSERT_EVENT_SQL_STMT,
+                "INSERT INTO audit_test.events (eventId, auditStream, eventJson) VALUES (?, ?, ?)");
+
+        ProcessingObjects processingObjects = new ProcessingObjects();
+        processingObjects.add(MapBasedCassandraPropsBuilder.KEY_CASSANDRA_CONNECTION_SESSION,
+                CassandraServer.getCluster().newSession());
+
+        CassandraProperties properties = new CassandraProperties();
+        properties.setAdditionalProperties(propsMap);
+
+        CommonProperties commonProperties = MapBasedCommonPropsBuilder.build(propsMap);
+        commonProperties.setDefaultAuditStream(T_AUDIT_STREAM_NAME);
+        commonProperties.setEncoding("UTF-8");
+        commonProperties.setFailOnMissingProcessors(true);
+        commonProperties.setProcessors(CassandraProcessor.class.getCanonicalName());
+
+        Audit audit = AuditFactory.getInstance(commonProperties.getAuditClassName(), commonProperties);
+        Event event = getTestEvent(commonProperties);
+        audit.audit(event, T_AUDIT_STREAM_NAME, processingObjects);
+
+        Session session = CassandraServer.getCluster().newSession();
+        ResultSet eventRs = session.execute("SELECT * FROM audit_test.events");
+
+        int resultSize = eventRs.all().size();
+
+        for(Row row : eventRs.all()){
+            String auditStreamName = row.getString("auditStream");
+            String eventJson = row.getString("eventJson");
+
+            String error = "The auditStreamName does not have the correct value";
+            assertThat(error, auditStreamName, is(equalTo(T_AUDIT_STREAM_NAME)));
+            error = "The eventJson does not have the correct value";
+            assertThat(error, eventJson, is(equalTo(T_EVENT_JSON)));
+        }
+
+        String error = "The event result set size does not have the correct size";
+        assertThat(error, resultSize, is(equalTo(1)));
+
+        session.close();
+
+        CassandraServer.cleanUp();
+    }
+
+    @Test(expected = AuditException.class)
+    public void shouldTryToInsertAnEventWithInvalidSql()
+            throws FactoryException, AuditException, IOException, SQLException, InterruptedException,
+            TTransportException {
+
+        CassandraServer.startCassandra();
+
+        Map<String, String> propsMap = new HashMap<>();
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_EVENT_ID_FIELD_NAME, EVENT_ID_FIELD_NAME);
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_INSERT_EVENT_SQL_STMT,
+                "INSERT INTO audit_test.events_invalid (eventId, auditStream, eventJson) VALUES (?, ?, ?)");
+        CassandraProperties properties = new CassandraProperties();
+        properties.setAdditionalProperties(propsMap);
+
+        ProcessingObjects processingObjects = new ProcessingObjects();
+        processingObjects.add(MapBasedCassandraPropsBuilder.KEY_CASSANDRA_CONNECTION_SESSION,
+                CassandraServer.getCluster().newSession());
+
+        CommonProperties commonProperties = MapBasedCommonPropsBuilder.build(propsMap);
+        commonProperties.setDefaultAuditStream(T_AUDIT_STREAM_NAME);
+        commonProperties.setEncoding("UTF-8");
+        commonProperties.setFailOnMissingProcessors(true);
+        commonProperties.setProcessors(CassandraProcessor.class.getCanonicalName());
+
+        Audit audit = AuditFactory.getInstance(commonProperties.getAuditClassName(), commonProperties);
+
+        Event event = getTestEvent(commonProperties);
+
+        try {
+            audit.audit(event, T_AUDIT_STREAM_NAME, processingObjects);
+        } catch (AuditException e) {
+            CassandraServer.cleanUp();
+            AuditErrorConditions expected = AuditErrorConditions.PROCESSING;
+            String error = "The type of exception thrown is not correct. Expected " + expected + ", got " + e.getErrorCondition();
+            assertThat(error, e.getErrorCondition(), is(equalTo(expected)));
+            throw e;
+        }
+    }
+
+    @Test(expected = AuditException.class)
+    public void shouldTryToInsertWithoutASession()
+        throws FactoryException, AuditException, IOException, InterruptedException, TTransportException {
+
+        Map<String, String> propsMap = new HashMap<>();
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_EVENT_ID_FIELD_NAME, EVENT_ID_FIELD_NAME);
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_INSERT_EVENT_SQL_STMT,
+            "INSERT INTO audit_test.events (eventId, auditStream, eventJson) VALUES (?, ?, ?)");
+
+        ProcessingObjects processingObjects = new ProcessingObjects();
+
+        CassandraProperties properties = new CassandraProperties();
+        properties.setAdditionalProperties(propsMap);
+
+        CommonProperties commonProperties = MapBasedCommonPropsBuilder.build(propsMap);
+        commonProperties.setDefaultAuditStream(T_AUDIT_STREAM_NAME);
+        commonProperties.setEncoding("UTF-8");
+        commonProperties.setFailOnMissingProcessors(true);
+        commonProperties.setProcessors(CassandraProcessor.class.getCanonicalName());
+
+        Audit audit = AuditFactory.getInstance(commonProperties.getAuditClassName(), commonProperties);
+        Event event = getTestEvent(commonProperties);
+        audit.audit(event, T_AUDIT_STREAM_NAME, processingObjects);
+
+    }
+
+    @Test(expected = AuditException.class)
+    public void shouldTryToInsertANullEvent()
+            throws FactoryException, AuditException, IOException, InterruptedException, TTransportException {
+
+        Map<String, String> propsMap = new HashMap<>();
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_EVENT_ID_FIELD_NAME, EVENT_ID_FIELD_NAME);
+        propsMap.put(MapBasedCassandraPropsBuilder.KEY_INSERT_EVENT_SQL_STMT,
+                "INSERT INTO audit_test.events_invalid (eventId, auditStream, eventJson) VALUES (?, ?, ?)");
+        CassandraProperties properties = new CassandraProperties();
+        properties.setAdditionalProperties(propsMap);
+
+        CommonProperties commonProperties = MapBasedCommonPropsBuilder.build(propsMap);
+        commonProperties.setDefaultAuditStream(T_AUDIT_STREAM_NAME);
+        commonProperties.setEncoding("UTF-8");
+        commonProperties.setFailOnMissingProcessors(true);
+        commonProperties.setProcessors(CassandraProcessor.class.getCanonicalName());
+
+        CassandraProcessor processor = new CassandraProcessor();
+        processor.init(commonProperties);
+        processor.process(null);
+    }
+
+    @Test(expected = AuditException.class)
+    public void shouldTryToInsertAnEventWithNullProperties()
+            throws FactoryException, AuditException, UnsupportedEncodingException {
+
+        Map<String, String> propsMap = new HashMap<>();
+        CommonProperties commonProperties = MapBasedCommonPropsBuilder.build(propsMap);
+        commonProperties.setProcessors(CassandraProcessor.class.getCanonicalName());
+
+        CassandraProcessor processor = new CassandraProcessor();
+        processor.init(commonProperties);
+        Event event = getTestEvent(commonProperties);
+        processor.process(event);
+    }
+
+    @Test
+    public void shouldRevert()
+            throws FactoryException, AuditException, UnsupportedEncodingException {
+
+        Map<String, String> propsMap = new HashMap<>();
+        CommonProperties commonProperties = MapBasedCommonPropsBuilder.build(propsMap);
+        commonProperties.setProcessors(CassandraProcessor.class.getCanonicalName());
+
+        CassandraProcessor processor = new CassandraProcessor();
+        Event event = getTestEvent(commonProperties);
+        assertEquals(event, processor.revert(event));
+    }
+
+    @Test(expected = AuditException.class)
+    public void shouldTryToInsertAnEventWithNullEventId()
+            throws FactoryException, AuditException, UnsupportedEncodingException {
+
+        Map<String, String> propsMap = new HashMap<>();
+        CommonProperties commonProperties = MapBasedCommonPropsBuilder.build(propsMap);
+        commonProperties.setDefaultAuditStream(T_AUDIT_STREAM_NAME);
+        commonProperties.setEncoding("UTF-8");
+        commonProperties.setFailOnMissingProcessors(true);
+        commonProperties.setProcessors(CassandraProcessor.class.getCanonicalName());
+
+        Audit audit = AuditFactory.getInstance(commonProperties.getAuditClassName(), commonProperties);
+
+        Event event = getTestEvent(commonProperties);
+        audit.audit(event);
+    }
+
+    private static Event getTestEvent(CommonProperties properties) throws UnsupportedEncodingException {
+        Field eventIdField = new EventField(EVENT_ID_FIELD_NAME, EVENT_ID.getBytes("UTF-8"));
+        Field field = new EventField("byteField", new Hex().encode("1234".getBytes("UTF-8")), Encodings.HEX);
+
+        return new EventBuilder(properties)
+                .setField(eventIdField)
+                .setSubject(T_SUBJECT.toCharArray())
+                .setObject(T_OBJECT.toCharArray())
+                .setActor(T_ACTOR.toCharArray())
+                .setResult(T_RESULT.toCharArray())
+                .setField(field)
+                .build();
+    }
+}

--- a/processors/cassandra/src/test/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraServer.java
+++ b/processors/cassandra/src/test/java/org/beiter/michael/eaudit4j/processors/cassandra/CassandraServer.java
@@ -1,0 +1,85 @@
+/*
+ * #%L
+ * This file is part of eAudit4j, a library for creating pluggable
+ * auditing solutions, providing an audit processor that persists
+ * audit events to a Cassandra database.
+ * %%
+ * Copyright (C) 2015 - 2016 Michael Beiter <michael@beiter.org>
+ * %%
+ * All rights reserved.
+ * .
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of the
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ * .
+ * .
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import org.apache.thrift.transport.TTransportException;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+
+import java.io.IOException;
+
+public class CassandraServer {
+
+    private static Cluster cluster;
+
+    public static void startCassandra() throws IOException, TTransportException, InterruptedException {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra(20000L);
+        cluster = new Cluster.Builder()
+                .addContactPoint("localhost")
+                .withPort(9142)
+                .build();
+        Session session = cluster.connect();
+
+        String[] createDb = new String[]{
+                "DROP KEYSPACE IF EXISTS audit;\n",
+                "CREATE KEYSPACE audit_test WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor' : 1};\n",
+                "CREATE TABLE audit_test.events (\n" +
+                        "  eventId     VARCHAR PRIMARY KEY,\n" +
+                        "  auditStream VARCHAR,\n" +
+                        "  eventJson   VARCHAR\n" +
+                        ");"
+        };
+
+        try {
+            for (String sql : createDb) {
+                session.execute(sql);
+            }
+        } finally {
+            if (!session.isClosed()) {
+                session.close();
+            }
+        }
+    }
+
+    public static Cluster getCluster() {
+        return cluster;
+    }
+
+    public static void cleanUp() throws InterruptedException {
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+        Thread.sleep(2000L);
+    }
+}

--- a/processors/cassandra/src/test/java/org/beiter/michael/eaudit4j/processors/cassandra/propsbuilder/MapBasedCassandraPropsBuilderTest.java
+++ b/processors/cassandra/src/test/java/org/beiter/michael/eaudit4j/processors/cassandra/propsbuilder/MapBasedCassandraPropsBuilderTest.java
@@ -1,0 +1,169 @@
+/*
+ * #%L
+ * This file is part of eAudit4j, a library for creating pluggable
+ * auditing solutions, providing an audit processor that persists
+ * audit events to a Cassandra database.
+ * %%
+ * Copyright (C) 2015 - 2016 Michael Beiter <michael@beiter.org>
+ * %%
+ * All rights reserved.
+ * .
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of the
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ * .
+ * .
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.beiter.michael.eaudit4j.processors.cassandra.propsbuilder;
+
+import org.beiter.michael.eaudit4j.processors.cassandra.CassandraProperties;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+
+public class MapBasedCassandraPropsBuilderTest {
+
+    @Test
+    public void shouldValidateAdditionalPropertiesNoSingleton() {
+
+        String key = "some property";
+        String value = "some value";
+
+        Map<String, String> map = new HashMap<>();
+
+        map.put(key, value);
+        CassandraProperties properties = MapBasedCassandraPropsBuilder.build(map);
+
+        String error = "The properties builder returns a singleton";
+        assertThat(error, map, is(not(sameInstance(properties.getAdditionalProperties()))));
+    }
+
+    @Test
+    public void shouldValidateDefaultInsertEventSqlStmt() {
+
+        CassandraProperties properties = MapBasedCassandraPropsBuilder.buildDefault();
+
+        String error = "INSERT Event SQL statement does not match expected default value";
+        assertThat(error, properties.getInsertEventSqlStmt(),
+                is(equalTo(MapBasedCassandraPropsBuilder.DEFAULT_INSERT_EVENT_SQL_STMT)));
+        error = "INSERT Event SQL statement  does not match expected value";
+        properties.setInsertEventSqlStmt("42");
+        assertThat(error, properties.getInsertEventSqlStmt(), is(equalTo("42")));
+    }
+
+    @Test
+    public void ShouldValidateInsertEventSqlStmt() {
+
+        Map<String, String> map = new HashMap<>();
+
+        map.put(MapBasedCassandraPropsBuilder.KEY_INSERT_EVENT_SQL_STMT, null);
+        CassandraProperties properties = MapBasedCassandraPropsBuilder.build(map);
+        String error = "INSERT Event SQL statement does not match expected default value";
+        assertThat(error, properties.getInsertEventSqlStmt(),
+                is(equalTo(MapBasedCassandraPropsBuilder.DEFAULT_INSERT_EVENT_SQL_STMT)));
+
+        map.put(MapBasedCassandraPropsBuilder.KEY_INSERT_EVENT_SQL_STMT, "42");
+        properties = MapBasedCassandraPropsBuilder.build(map);
+        error = "INSERT Event SQL statement does not match expected value";
+        assertThat(error, properties.getInsertEventSqlStmt(), is(equalTo("42")));
+
+        CassandraProperties properties2 = new CassandraProperties(properties);
+        error = "copy constructor does not copy field";
+        assertThat(error, properties2.getInsertEventSqlStmt(), is(equalTo("42")));
+    }
+
+    @Test
+    public void shouldValidateDefaultStringEncodingTest() {
+
+        CassandraProperties properties = MapBasedCassandraPropsBuilder.buildDefault();
+
+        String error = "String encoding does not match expected default value";
+        assertThat(error, properties.getStringEncoding(),
+                is(equalTo(MapBasedCassandraPropsBuilder.DEFAULT_STRING_ENCODING)));
+        error = "String encoding does not match expected value";
+        properties.setStringEncoding("42");
+        assertThat(error, properties.getStringEncoding(), is(equalTo("42")));
+    }
+
+    @Test
+    public void shouldValidateStringEncodingTest() {
+
+        Map<String, String> map = new HashMap<>();
+
+        map.put(MapBasedCassandraPropsBuilder.KEY_STRING_ENCODING, null);
+        CassandraProperties properties = MapBasedCassandraPropsBuilder.build(map);
+        String error = "String encoding does not match expected default value";
+        assertThat(error, properties.getStringEncoding(),
+                is(equalTo(MapBasedCassandraPropsBuilder.DEFAULT_STRING_ENCODING)));
+
+        map.put(MapBasedCassandraPropsBuilder.KEY_STRING_ENCODING, "42");
+        properties = MapBasedCassandraPropsBuilder.build(map);
+        error = "String encoding does not match expected value";
+        assertThat(error, properties.getStringEncoding(), is(equalTo("42")));
+
+        CassandraProperties properties2 = new CassandraProperties(properties);
+        error = "copy constructor does not copy field";
+        assertThat(error, properties2.getStringEncoding(), is(equalTo("42")));
+    }
+
+
+    @Test
+    public void shouldValidateDefaultEventIdFieldNameTest() {
+
+        CassandraProperties properties = MapBasedCassandraPropsBuilder.buildDefault();
+
+        String error = "Event ID field name does not match expected default value";
+        assertThat(error, properties.getEventIdFieldName(),
+                is(equalTo(MapBasedCassandraPropsBuilder.DEFAULT_EVENT_ID_FIELD_NAME)));
+        error = "Event ID field name does not match expected value";
+        properties.setEventIdFieldName("42");
+        assertThat(error, properties.getEventIdFieldName(), is(equalTo("42")));
+    }
+
+
+    @Test
+    public void shouldValidateEventIdFieldNameTest() {
+
+        Map<String, String> map = new HashMap<>();
+
+        map.put(MapBasedCassandraPropsBuilder.KEY_EVENT_ID_FIELD_NAME, null);
+        CassandraProperties properties = MapBasedCassandraPropsBuilder.build(map);
+        String error = "Event ID field name does not match expected default value";
+        assertThat(error, properties.getEventIdFieldName(),
+                is(equalTo(MapBasedCassandraPropsBuilder.DEFAULT_EVENT_ID_FIELD_NAME)));
+
+        map.put(MapBasedCassandraPropsBuilder.KEY_EVENT_ID_FIELD_NAME, "42");
+        properties = MapBasedCassandraPropsBuilder.build(map);
+        error = "Event ID field name does not match expected value";
+        assertThat(error, properties.getEventIdFieldName(), is(equalTo("42")));
+
+        CassandraProperties properties2 = new CassandraProperties(properties);
+        error = "copy constructor does not copy field";
+        assertThat(error, properties2.getEventIdFieldName(), is(equalTo("42")));
+    }
+}

--- a/processors/cassandra/src/test/resources/log4j.properties
+++ b/processors/cassandra/src/test/resources/log4j.properties
@@ -1,0 +1,32 @@
+# See http://logging.apache.org/log4j/1.2/manual.html for options
+#################################################################
+
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=DEBUG, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# Print only messages of level WARN or above in the package org.apache.
+log4j.logger.org.apache=WARN
+
+# Define the AUDIT appender
+# =========================
+
+# log audit events with log level "DEBUG" or higher in the AUDIT log
+log4j.category.org.beiter.michael.eaudit4j.processors.slf4j.Slf4jProcessor=DEBUG, AUDIT
+
+# Don't log audit events (i.e. events created by the configured audit class) in other loggers than the audit logger
+log4j.additivity.org.beiter.michael.eaudit4j.processors.slf4j.Slf4jProcessor=false
+
+# You may configure a JNDI or JDBC appender here, but note that e.g. the log4j DB appenders are not very fast
+# In this example, we use a console appender with a pattern layout, listing:
+#  - the log message and
+#  - the MDC elements we are interested in
+log4j.appender.AUDIT=org.apache.log4j.ConsoleAppender
+log4j.appender.AUDIT.layout=org.apache.log4j.PatternLayout
+log4j.appender.AUDIT.layout.ConversionPattern=%m |-MDC-> auditStream:%X{org.beiter.eaudit4j.auditStream},subject:%X{subject},actor:%X{myActor},someByteField:%X{byteField} %n

--- a/processors/pom.xml
+++ b/processors/pom.xml
@@ -28,6 +28,7 @@
 		<module>eventId</module>
         <module>slf4j</module>
         <module>jdbc</module>
+        <module>cassandra</module>
     </modules>
 
     <scm>


### PR DESCRIPTION
- Adding a new processor to persist events on cassandra database; The cassandra processor receives a Cassandra session instance as a processing object to handle the connection with Cassandra. (review @mbeiter)
- Adding unit tests for the new cassandra processor. The unit tests use [cassandra-unit](https://github.com/jsevellec/cassandra-unit) as an embedded server;
- Updating CONFIG.md file
